### PR TITLE
docs: Add comprehensive infrastructure management guide

### DIFF
--- a/INFRA.md
+++ b/INFRA.md
@@ -1,0 +1,164 @@
+# Infrastructure Management Guide
+
+This document provides guidance for building and managing infrastructure for the tonys-chips project using System Initiative.
+
+## Naming Conventions
+
+- **Primary Convention**: Use `kebab-case` for all resource names where possible
+- **Fallback Convention**: Use `lowerCamelCase` when kebab-case is not permitted by the service
+- **Name Tags**: When resources support a `Name` tag, it MUST match the `si/name` value
+
+### Examples
+
+**Good:**
+```
+si/name: tonys-chips-api-server
+Name tag: tonys-chips-api-server
+```
+
+**When kebab-case not supported:**
+```
+si/name: tonysChipsApiServer
+Name tag: tonysChipsApiServer
+```
+
+## AWS Tagging Policy
+
+### Required Tags
+
+Every AWS resource MUST include the following tags:
+
+#### Environment
+Indicates the deployment environment.
+
+**Valid Values:**
+- `Sandbox`
+- `Shared`
+- `Dev`
+- `PreProd`
+- `Prod`
+
+#### Owner
+Email address of the person or team responsible for the resource.
+
+**Rules:**
+- Initially set to creator's email if unknown
+- Must be a valid email address
+- Should be updated if ownership changes
+
+#### CostCenter
+Internal accounting reference for cost allocation and chargeback.
+
+**Valid Values:**
+- `ProjectApollo`
+- `ProjectOrigin`
+- `CustomerPortal`
+- `DevelopmentSandbox`
+- `TestingQA`
+
+**Default:** Use `DevelopmentSandbox` for unallocated or unknown cases.
+
+#### Application
+The service, product, or project name this resource supports.
+
+**Rules:**
+- Create a new name if the resource is unallocated or for an unknown case
+- Should be descriptive and consistent across related resources
+- Examples: `tonys-chips-api`, `tonys-chips-web`, `tonys-chips-data-pipeline`
+
+### Tag Formatting Standards
+
+#### Tag Keys
+- MUST use `PascalCase` (e.g., `CostCenter`, `Application`, `Owner`)
+- No spaces, hyphens, or underscores
+
+#### Tag Values
+- MUST come from approved lists where applicable (see above)
+- Free-form values allowed when no approved list exists
+- Free-form tags may be used for special cases but MUST NOT conflict with organizational tags
+
+### Enforcement and Compliance
+
+**Non-Compliance Consequences:**
+- Resources without required tags may be automatically stopped
+- Creation requests may be denied at the policy level
+- Resources flagged for remediation during audits
+
+**Accountability:**
+- Teams are responsible for maintaining tag accuracy
+- Stale or incorrect tags will be flagged during periodic audits
+- Tags should be reviewed and updated as part of infrastructure changes
+
+### Cost Allocation and Chargeback
+
+**CostCenter Requirements:**
+- The `CostCenter` tag is REQUIRED on all billable resources:
+  - EC2 instances
+  - RDS databases
+  - S3 buckets
+  - Lambda functions
+  - Load balancers
+  - NAT gateways
+  - Any other resource that incurs direct costs
+
+**Financial Impact:**
+- Untagged resources may be assigned to a default CostCenter
+- Untagged resources are subject to higher internal chargeback rates
+- Proper tagging ensures accurate cost attribution to your team/project
+
+## Working with System Initiative
+
+### Change Set Workflow
+
+1. **Create a Change Set** - All infrastructure changes MUST be made in a change set, never directly in HEAD
+2. **Make Changes** - Create, update, or delete components as needed
+3. **Check Qualifications** - Review qualification results to ensure changes are valid
+4. **Apply to HEAD** - Once validated, apply the change set to make changes live
+5. **Monitor Actions** - Check for action failures after applying
+
+### Component Configuration
+
+When creating AWS components in System Initiative:
+
+1. **Always set required subscriptions:**
+   - `/secrets/AWS Credential` → Subscribe to AWS Credential component
+   - `/domain/extra/Region` → Subscribe to Region component
+
+2. **Always configure required tags:**
+   ```
+   /domain/Tags/0/Key: "Environment"
+   /domain/Tags/0/Value: "Dev"
+
+   /domain/Tags/1/Key: "Owner"
+   /domain/Tags/1/Value: "your-email@example.com"
+
+   /domain/Tags/2/Key: "CostCenter"
+   /domain/Tags/2/Value: "DevelopmentSandbox"
+
+   /domain/Tags/3/Key: "Application"
+   /domain/Tags/3/Value: "tonys-chips-api"
+   ```
+
+3. **Set Name tag to match si/name:**
+   ```
+   /domain/si/name: "tonys-chips-api-server"
+   /domain/Tags/4/Key: "Name"
+   /domain/Tags/4/Value: "tonys-chips-api-server"
+   ```
+
+### Best Practices
+
+- **Validate Before Apply**: Always check component qualifications before applying a change set
+- **Use Descriptive Names**: Resource names should clearly indicate their purpose
+- **Group Related Resources**: Use consistent naming prefixes for resources that work together
+- **Document Complex Configurations**: Add comments or descriptions in System Initiative for non-obvious setups
+- **Review Tags Regularly**: Audit tags during infrastructure reviews to ensure accuracy
+- **Update Tags on Changes**: When a resource's purpose or ownership changes, update tags immediately
+
+## Getting Help
+
+For questions about:
+- **System Initiative Usage**: Consult the System Initiative documentation or your infrastructure team
+- **Tag Policies**: Contact the FinOps or Cloud Governance team
+- **Cost Centers**: Reach out to Finance or your team lead
+- **Infrastructure Design**: Consult with the platform engineering team

--- a/build-log/2025-10-14.md
+++ b/build-log/2025-10-14.md
@@ -56,3 +56,86 @@ now update the existing summary to include the email appropriately
 ## Next Steps
 
 None - the prompt template is now comprehensive and ready for use.
+
+---
+
+# Created Infrastructure Management Guide
+
+**Author**: adam@systeminit.com
+
+## Summary
+
+Created a comprehensive INFRA.md file for the tonys-chips project that establishes naming conventions, AWS tagging policies, and System Initiative workflow guidance. This document serves as the authoritative reference for infrastructure management standards across the project.
+
+## Changes Made
+
+- **Files Created**: `/home/adam/src/tonys/tonys-chips/INFRA.md`
+
+## Technical Decisions
+
+**Naming Conventions:**
+- Established kebab-case as the primary naming convention with lowerCamelCase as fallback
+- Required Name tags to match si/name for consistency across infrastructure and UI
+
+**AWS Tagging Policy:**
+- Defined five required tags for all AWS resources: Environment, Owner, CostCenter, Application
+- Standardized on PascalCase for tag keys
+- Created approved value lists for Environment (Sandbox, Shared, Dev, PreProd, Prod) and CostCenter (ProjectApollo, ProjectOrigin, CustomerPortal, DevelopmentSandbox, TestingQA)
+- Established DevelopmentSandbox as default CostCenter for unallocated resources
+
+**Enforcement Strategy:**
+- Documented consequences for non-compliance (automatic stops, creation denials, audit flagging)
+- Emphasized team accountability for tag accuracy
+- Highlighted financial impact through chargeback mechanisms
+
+**System Initiative Integration:**
+- Documented Change Set workflow (create → make changes → check qualifications → apply → monitor actions)
+- Provided component configuration examples with proper subscription patterns
+- Established best practices for validation and tag management
+
+**Rationale:**
+This document ensures consistency across the team, enables accurate cost allocation, and provides clear guidance for both new and experienced users working with System Initiative and AWS infrastructure.
+
+## Issues Encountered
+
+**Initial Environment Values:**
+User corrected the Environment tag values from the initial set (Production, Staging, Development, Sandbox) to the correct organizational standard (Sandbox, Shared, Dev, PreProd, Prod) before the file was created.
+
+## Prompts
+
+```prompt
+add a ../tonys-chips/INFRA.md file with guidance for working with System Initiative to build and manage infrastructure for the project. it should specify that we name things with kebab-case where possible, lower camel where that is not permitted, use Name tags when we need them that should match the si/name, and this tag policy: Every AWS resource must include the following tags at minimum:
+- Environment (Production, Staging, Development, Sandbox)
+- Owner (email responsible, initially set to creator email if unknown)
+- CostCenter (internal accounting reference). One of:
+    - ProjectApollo
+    - ProjectOrigin
+    - CustomerPortal
+    - DevelopmentSandbox
+    - TestingQA
+  Default to DevelopmentSandbox for unallocated or unknown cases.
+- Application (service, product, or project name) Create new name if unallocated or unknown cases
+
+** Standardized Tag Keys and Values **
+- All tag keys must use PascalCase (e.g., CostCenter, Application).
+- All tag values must come from an approved list where applicable (e.g., Environment must be one of: Production, Staging, Development, Sandbox).
+
+Free-form tags may be used for special cases, but should not conflict with organizational tags.
+
+Resources without required tags may be automatically stopped, denied creation, or flagged for remediation.
+
+Teams are accountable for maintaining tag accuracy; stale or incorrect tags will be flagged during audits.
+
+Cost Allocation and Chargeback - The CostCenter tag is required on all billable resources (EC2, RDS, S3 buckets, Lambda, etc.). Untagged resources may be assigned to a default CostCenter and subject to higher internal chargeback rates.
+```
+
+```prompt
+environments should be Sandbox, Shared, Dev, PreProd, Prod
+```
+
+## Next Steps
+
+- Apply these standards to existing infrastructure in System Initiative
+- Create example components demonstrating proper tag configuration
+- Consider adding validation scripts or policies to enforce tagging requirements
+- Document any project-specific Application names as they are created


### PR DESCRIPTION
Create INFRA.md establishing standards for System Initiative workflows:
- Naming conventions (kebab-case primary, lowerCamelCase fallback)
- AWS tagging policy with required tags (Environment, Owner, CostCenter, Application)
- Tag enforcement and cost allocation guidelines
- System Initiative Change Set workflow documentation
- Component configuration examples with proper subscriptions

Update build-log/2025-10-14.md with session summary documenting the infrastructure guide creation and rationale for the established standards.