### PR TITLE
docs: Add session log for default AWS infrastructure discovery

### DIFF
--- a/build-log/2025-10-14.md
+++ b/build-log/2025-10-14.md
@@ -139,3 +139,77 @@ environments should be Sandbox, Shared, Dev, PreProd, Prod
 - Create example components demonstrating proper tag configuration
 - Consider adding validation scripts or policies to enforce tagging requirements
 - Document any project-specific Application names as they are created
+
+---
+
+# Discovered Default AWS Infrastructure
+
+**Author**: adam@systeminit.com
+
+## Summary
+
+Discovered and imported all default AWS infrastructure components in the us-east-1 region into System Initiative. This included the default VPC, all six default subnets (one per availability zone), the internet gateway, route table, and default security group. All components were renamed following the `sandbox-default-*` naming convention for clear identification.
+
+## Changes Made
+
+- **Infrastructure Created**:
+  - `sandbox-default-vpc` (AWS::EC2::VPC)
+  - `sandbox-default-subnet-us-east-1a` (AWS::EC2::Subnet)
+  - `sandbox-default-subnet-us-east-1b` (AWS::EC2::Subnet)
+  - `sandbox-default-subnet-us-east-1c` (AWS::EC2::Subnet)
+  - `sandbox-default-subnet-us-east-1d` (AWS::EC2::Subnet)
+  - `sandbox-default-subnet-us-east-1e` (AWS::EC2::Subnet)
+  - `sandbox-default-subnet-us-east-1f` (AWS::EC2::Subnet)
+  - `sandbox-default-internet-gateway` (AWS::EC2::InternetGateway)
+  - `sandbox-default-route-table` (AWS::EC2::RouteTable)
+  - `sandbox-default-security-group` (AWS::EC2::SecurityGroup)
+
+## Technical Decisions
+
+**Discovery vs Import Approach:**
+- Used `component-discover` for VPC, Subnets, and Internet Gateway (succeeded without refinement)
+- For RouteTable and SecurityGroup, the discover function required `/domain/VpcId` refinement parameter
+- Discovery function succeeded but didn't automatically create components, so used `component-import` with resource IDs from function logs
+
+**VpcId Refinement Requirement:**
+- Both `AWS::EC2::RouteTable` and `AWS::EC2::SecurityGroup` schemas require the `/domain/VpcId` attribute to be set as a subscription to the VPC's `/resource_value/VpcId` for successful discovery
+- This filtering ensures we only discover resources associated with the specific VPC
+
+**Naming Strategy:**
+- Used `sandbox-default-*` prefix to clearly indicate these are default AWS resources in the sandbox environment
+- Subnet names include availability zone suffix for easy identification (e.g., `sandbox-default-subnet-us-east-1a`)
+- Follows the kebab-case convention established in INFRA.md
+
+## Issues Encountered
+
+**Route Table Discovery Failure:**
+- Initial discovery attempt failed with error: "Cannot read properties of undefined (reading 'find')"
+- Root cause: Missing required `/domain/VpcId` refinement parameter
+- Solution: Updated discover component with VpcId subscription before running discovery
+- Same pattern applied successfully to SecurityGroup discovery
+
+**Component Creation Not Automatic:**
+- Discovery management functions returned success and found resources, but didn't automatically create the components in the workspace
+- Function logs showed the resource data and creation specifications
+- Workaround: Used `component-import` with the resource IDs identified in the function logs to directly import the components
+
+## Prompts
+
+```prompt
+discover the default AWS infrastructure, and name all the resulting components 'sandbox-default-whatever', where 'whatever' is representative of their function
+```
+
+```prompt
+look at the failed action for discovering the route table, and update the Discover component for the route tables with the correct refinement
+```
+
+```prompt
+now do the same for security group
+```
+
+## Next Steps
+
+- Apply the change set to HEAD to make these components visible in production
+- Add required tags (Environment, Owner, CostCenter, Application) to all discovered components per INFRA.md standards
+- Review and document the default VPC configuration (CIDR blocks, routing, security rules)
+- Consider whether to keep using default VPC or create custom VPC with proper naming and tagging


### PR DESCRIPTION
Discovered and documented all default AWS infrastructure components in System Initiative including VPC, subnets, internet gateway, route table, and security group. All components renamed with sandbox-default-* naming convention.

Key learnings:
- RouteTable and SecurityGroup discovery require VpcId refinement
- Discovery functions may succeed but not auto-create components
- Used component-import as workaround with resource IDs from logs