### PR TITLE
feat(compose): Ensure that docker compose doesn't use build context

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,21 @@ This project is organized as a monorepo with the following structure:
    cd sample-app
    ```
 
-2. **Start the application**
+2. **Build the Docker images**
+   ```bash
+   npm run build:local
+   ```
+
+3. **Start the application**
    ```bash
    npm run docker:up
    ```
 
-3. **Access the application**
+4. **Access the application**
    - Web UI: http://localhost:8080 (Express server with EJS templates)
    - API: http://localhost:3000/api
 
-4. **Stop the application**
+5. **Stop the application**
    ```bash
    npm run docker:down
    ```
@@ -59,18 +64,23 @@ This project is organized as a monorepo with the following structure:
 #### Option 1: Docker Compose (Easiest)
 
 ```bash
+# Build images first (required before first run)
+npm run build:local              # Build API, web, and E2E images
+
 # Start all services (postgres, api, web)
-npm run docker:up
+npm run docker:up                # Start in foreground
+docker-compose up -d             # Start in background
 
 # View logs for all services
-npm run docker:logs
-
-# View logs for specific service
-docker-compose logs api
-docker-compose logs web
+npm run docker:logs              # Follow all logs
+docker-compose logs -f api       # Follow API logs only
+docker-compose logs -f web       # Follow web logs only
 
 # Stop all services
 npm run docker:down
+
+# Use specific image version (bypassing npm scripts)
+IMAGE_TAG=20250115120000-abc123 docker-compose up
 ```
 
 The database is automatically migrated and seeded with sample products on startup. The web service runs on port 8080 (mapped from container port 3001).
@@ -138,10 +148,16 @@ The web UI will run on http://localhost:3001
 #### Root Commands
 ```bash
 npm install                    # Install all workspace dependencies
-npm run docker:up              # Start Docker Compose stack
-npm run docker:down            # Stop Docker Compose stack
+
+# Local build commands
+npm run build:local            # Build API, web, and E2E images (latest tag)
+
+# Docker compose commands
+npm run docker:up              # Start all services (foreground)
+npm run docker:down            # Stop all services
 npm run docker:logs            # View logs from all services
-npm run docker:build:e2e       # Build E2E test Docker image
+
+# E2E testing
 npm run docker:test:e2e        # Run E2E tests in Docker against local services
 ```
 
@@ -192,8 +208,8 @@ npm run test:coverage
 npm run test:e2e
 
 # Run E2E tests in Docker against local docker-compose services
-npm run docker:build:e2e   # Build image (first time only)
-npm run docker:test:e2e    # Run tests
+npm run build:local         # Build images (first time only, builds all including E2E)
+npm run docker:test:e2e     # Run tests
 
 # Run with UI mode (interactive, local only)
 npm run test:e2e:ui
@@ -204,8 +220,8 @@ npm run test:e2e:report
 
 **Docker E2E Testing:**
 ```bash
-# Build the E2E test image
-npm run docker:build:e2e
+# Build all images including E2E (local development)
+npm run build:local
 
 # Run against local docker-compose services
 npm run docker:test:e2e
@@ -270,15 +286,15 @@ docker run --rm \
 ### Building for Production
 
 ```bash
-# Build Docker images
+# Build Docker images for local development
+npm run build:local
+
+# Or build directly with docker
 docker build -f docker/api.Dockerfile -t tonys-chips-api:latest .
 docker build -f docker/web.Dockerfile -t tonys-chips-web:latest .
 docker build -f docker/e2e.Dockerfile -t tonys-chips-e2e:latest .
 
-# Or use npm scripts
-npm run docker:build:e2e
-
-# Build locally
+# Build locally (native)
 npm run build --workspace=@chips/api
 npm run build --workspace=@chips/web
 ```

--- a/ci/commands/build-local.ts
+++ b/ci/commands/build-local.ts
@@ -1,0 +1,72 @@
+/**
+ * Local Docker build command implementation
+ * Builds images with the 'latest' tag for local development
+ */
+
+import { execSync } from "child_process";
+
+function runCommand(command: string, description: string): void {
+  console.log(`🔧 ${description}`);
+  console.log(`   Command: ${command}`);
+
+  try {
+    execSync(command, { stdio: "inherit" });
+    console.log(`✅ Success: ${description}`);
+  } catch (error) {
+    console.error(`❌ Failed: ${description}`);
+    throw new Error(`Command failed: ${description}`);
+  }
+}
+
+export async function buildLocal(args: string[]): Promise<void> {
+  console.log("🚀 Building Docker images for local development");
+  console.log("");
+
+  const component = args[0] || "all";
+
+  const validComponents = ["all", "api", "web", "e2e"];
+  if (!validComponents.includes(component)) {
+    throw new Error(
+      `Invalid component: ${component}. Must be one of: ${
+        validComponents.join(", ")
+      }`,
+    );
+  }
+
+  const builtImages: string[] = [];
+
+  // Build API image
+  if (component === "all" || component === "api") {
+    runCommand(
+      "docker build -f docker/api.Dockerfile -t tonys-chips-api:latest .",
+      "Building API Docker image",
+    );
+    builtImages.push("tonys-chips-api:latest");
+  }
+
+  // Build Web image
+  if (component === "all" || component === "web") {
+    runCommand(
+      "docker build -f docker/web.Dockerfile -t tonys-chips-web:latest .",
+      "Building Web Docker image",
+    );
+    builtImages.push("tonys-chips-web:latest");
+  }
+
+  // Build E2E image
+  if (component === "all" || component === "e2e") {
+    runCommand(
+      "docker build -f docker/e2e.Dockerfile -t tonys-chips-e2e:latest .",
+      "Building E2E test Docker image",
+    );
+    builtImages.push("tonys-chips-e2e:latest");
+  }
+
+  console.log("");
+  console.log("🎉 Successfully built Docker images:");
+  builtImages.forEach((image) => console.log(`   ${image}`));
+  console.log("");
+  console.log("💡 Next steps:");
+  console.log("   Start services: npm run docker:up");
+  console.log("   Or use:         docker-compose up");
+}

--- a/ci/commands/test-e2e.ts
+++ b/ci/commands/test-e2e.ts
@@ -1,0 +1,31 @@
+/**
+ * E2E test command implementation
+ * Runs E2E tests in Docker container
+ */
+
+import { execSync } from 'child_process';
+
+export async function testE2e(args: string[]): Promise<void> {
+  console.log("🧪 Running E2E tests in Docker");
+  console.log("");
+
+  const apiUrl = process.env.API_URL || 'http://localhost:3000';
+  const webUrl = process.env.WEB_URL || 'http://localhost:8080';
+
+  console.log(`📋 Configuration:`);
+  console.log(`   API URL: ${apiUrl}`);
+  console.log(`   Web URL: ${webUrl}`);
+  console.log("");
+
+  const command = `docker run --rm --network host -e API_URL=${apiUrl} -e WEB_URL=${webUrl} tonys-chips-e2e:latest`;
+
+  try {
+    execSync(command, { stdio: 'inherit' });
+    console.log("");
+    console.log("✅ E2E tests passed");
+  } catch (error) {
+    console.error("");
+    console.error("❌ E2E tests failed");
+    throw error;
+  }
+}

--- a/ci/main.ts
+++ b/ci/main.ts
@@ -10,6 +10,8 @@ import { checkPostgres } from './commands/check-postgres.js';
 import { build } from './commands/build.js';
 import { publish } from './commands/publish.js';
 import { pushImage } from './commands/push-image.js';
+import { buildLocal } from './commands/build-local.js';
+import { testE2e } from './commands/test-e2e.js';
 
 interface Command {
   name: string;
@@ -33,21 +35,33 @@ const commands: Command[] = [
   },
   {
     name: "build",
-    description: "Build Docker images",
-    usage: "build <environment> <tag> [--api] [--web]",
+    description: "Build Docker images for deployment",
+    usage: "build <environment> <component> <tag>  (component: api|web|e2e)",
     execute: build,
   },
   {
     name: "publish",
     description: "Publish Docker images to ECR",
-    usage: "publish <environment> <tag> [--api] [--web]",
+    usage: "publish <environment> <component> <tag>  (component: api|web|e2e)",
     execute: publish,
   },
   {
     name: "push-image",
-    description: "Build and push both Docker images to ECR (combined)",
-    usage: "push-image <environment> <tag>",
+    description: "Build and push Docker image to ECR (combined build + publish)",
+    usage: "push-image <environment> <component> <tag>  (component: api|web|e2e)",
     execute: pushImage,
+  },
+  {
+    name: "build-local",
+    description: "Build Docker images for local development (latest tag)",
+    usage: "build-local [all|api|web|e2e]",
+    execute: buildLocal,
+  },
+  {
+    name: "test-e2e",
+    description: "Run E2E tests in Docker container",
+    usage: "test-e2e",
+    execute: testE2e,
   },
 ];
 
@@ -66,7 +80,8 @@ function showHelp() {
   
   console.log("Examples:");
   console.log("  tsx ci/main.ts calver");
-  console.log("  tsx ci/main.ts check-postgres local 60");
+  console.log("  tsx ci/main.ts build-local all");
+  console.log("  tsx ci/main.ts test-e2e");
   console.log("  tsx ci/main.ts push-image sandbox 20231201120000-abc1234");
   console.log("");
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,7 @@ services:
       - chips-network
 
   api:
-    build:
-      context: .
-      dockerfile: docker/api.Dockerfile
+    image: tonys-chips-api:${IMAGE_TAG:-latest}
     container_name: tonys-chips-api
     environment:
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/tonys_chips
@@ -39,9 +37,7 @@ services:
       - chips-network
 
   web:
-    build:
-      context: .
-      dockerfile: docker/web.Dockerfile
+    image: tonys-chips-web:${IMAGE_TAG:-latest}
     container_name: tonys-chips-web
     environment:
       API_URL: http://api:3000

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
     "packages/*"
   ],
   "scripts": {
-    "docker:up": "docker-compose up --build",
+    "build:local": "npx tsx ci/main.ts build-local all",
+    "docker:up": "docker-compose up",
     "docker:down": "docker-compose down",
     "docker:logs": "docker-compose logs -f",
-    "docker:build:e2e": "docker build -f docker/e2e.Dockerfile -t tonys-chips-e2e:latest .",
-    "docker:test:e2e": "docker run --rm --network host -e API_URL=http://localhost:3000 -e WEB_URL=http://localhost:8080 tonys-chips-e2e:latest",
+    "docker:test:e2e": "npx tsx ci/main.ts test-e2e",
     "ci:calver": "npx tsx ci/main.ts calver",
     "ci:check-postgres": "npx tsx ci/main.ts check-postgres",
     "ci:build": "npx tsx ci/main.ts build",
@@ -27,7 +27,8 @@
   "description": "Tony's World of Chips - E-commerce storefront",
   "devDependencies": {
     "@playwright/test": "^1.56.0",
-    "playwright": "^1.56.0","@types/node": "^20.0.0",
+    "playwright": "^1.56.0",
+    "@types/node": "^20.0.0",
     "tsx": "^4.0.0",
     "typescript": "^5.0.0"
   }


### PR DESCRIPTION
We don’t want to depend on the compose file building locall - we have convenience wrappers for building and this way will allow us to run compose on PR environments