### PR TITLE
fixup: deploy was looping over components in `all` case. Remove all component input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ npx tsx ci/main.ts build-local e2e    # Build only E2E test image
 # Image Lifecycle Management Commands (CI/Deployment with specific tags)
 npx tsx ci/main.ts manage-image-lifecycle build <environment> <component> <tag>    # Build only
 npx tsx ci/main.ts manage-image-lifecycle publish <environment> <component> <tag>  # Publish only
-npx tsx ci/main.ts manage-image-lifecycle deploy <environment> <component> <tag>   # Deploy (unimplemented)
+npx tsx ci/main.ts manage-image-lifecycle deploy <environment> <tag>   # Deploy all components
 
 # Docker Compose orchestration (direct docker-compose commands)
 npm run docker:up            # Start services using latest tag (foreground)

--- a/ci/main.ts
+++ b/ci/main.ts
@@ -72,8 +72,8 @@ const commands: Command[] = [
   },
   {
     name: "manage-image-lifecycle",
-    description: "Unified image lifecycle management (build, publish, push)",
-    usage: "manage-image-lifecycle <action> <environment> <component> <tag>  (action: build|publish|push|deploy, component: api|web|e2e)",
+    description: "Unified image lifecycle management (build, publish, push, deploy)",
+    usage: "build|publish|push: <action> <environment> <component> <tag> | deploy: deploy <environment> <tag>",
     execute: manageImageLifecycle,
   },
 ];


### PR DESCRIPTION
It doesn't make any sense to loop over components in deployment, as we are centrally deploying/unilateral deployment for all applications of a given tag/version.